### PR TITLE
Docs: Adding dark mode support to code sample

### DIFF
--- a/_sass/_highlight.scss
+++ b/_sass/_highlight.scss
@@ -5,11 +5,58 @@
     }    
 }
 
+:root,
+[data-bs-theme="light"] {
+  --base00: #fafafa;
+  --base01: #666;
+  --base02: #cd3c14;
+  --base03: #345aad;
+  --base04: #145114;
+  --base05: #053871;
+  --base06: #595959;
+  --base07: #ffceef;
+  --base08: #071b07;
+  --base09: #a7cfa7;
+  --base0A: #0d162b;
+  --base0B: #064b97;
+  --base0C: #914200;
+  --base0D: #3a1a74;
+  --base0E: #085827;
+  --base0F: #000;
+  --base10: #ddd;
+  --base11: #5e4204;
+  --base12: #03264c;
+  --base13: #712e5c;
+}
+
+[data-bs-theme="dark"] {
+  --base00: #000;
+  --base01: #ccc;
+  --base02: #50be87;
+  --base03: #4bb4e6;
+  --base04: #ffd200;
+  --base05: #3e9dd6;
+  --base06: #ddd;
+  --base07: #712e5c;
+  --base08: #4bb4e6;
+  --base09: #0e360e;
+  --base0A: #b3c6ef;
+  --base0B: #237eca;
+  --base0C: #f7a866;
+  --base0D: #a885d8;
+  --base0E: #27a971;
+  --base0F: #fff;
+  --base10: #666;
+  --base11: #4e9f4e;
+  --base12: #237eca;
+  --base13: #d573bb;
+}
+
 .highlight {
     padding: 1.25rem;
     margin-bottom: 1.25rem;
-    background-color: #fafafa;
-    border: .125rem solid #ddd;
+    background-color: var(--base00);
+    border: .125rem solid var(--bs-border-color-subtle);
 }
 
 .highlight pre {
@@ -24,62 +71,62 @@
     border: 0;
 }
 
-.highlight .c { color: #999988; font-style: italic } /* Comment */
-.highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
-.highlight .k { font-weight: bold } /* Keyword */
-.highlight .o { font-weight: bold } /* Operator */
-.highlight .cm { color: #999988; font-style: italic } /* Comment.Multiline */
-.highlight .cp { color: #999999; font-weight: bold } /* Comment.Preproc */
-.highlight .c1 { color: #999988; font-style: italic } /* Comment.Single */
-.highlight .cs { color: #999999; font-weight: bold; font-style: italic } /* Comment.Special */
-.highlight .gd { color: #000000; background-color: #ffdddd } /* Generic.Deleted */
-.highlight .gd .x { color: #000000; background-color: #ffaaaa } /* Generic.Deleted.Specific */
+.highlight .c { color: var(--base01); font-style: italic } /* Comment */
+.highlight .err { color: var(--base02); background-color: transparent } /* Error */
+.highlight .k { color: var(--base03); font-weight: bold } /* Keyword */
+.highlight .o { color: var(--base01); font-weight: bold } /* Operator */
+.highlight .cm { color: var(--base01); font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: var(--base05); font-weight: bold } /* Comment.Preproc */
+.highlight .c1 { color: var(--base06); font-style: italic } /* Comment.Single */
+.highlight .cs { color: var(--base06); font-weight: bold; font-style: italic } /* Comment.Special */
+.highlight .gd { background-color: var(--base07); border: 1px solid var(--base02) } /* Generic.Deleted */
+.highlight .gd .x { background-color: var(--base07); border: 1px solid var(--base02) } /* Generic.Deleted.Specific */
 .highlight .ge { font-style: italic } /* Generic.Emph */
-.highlight .gr { color: #aa0000 } /* Generic.Error */
-.highlight .gh { color: #999999 } /* Generic.Heading */
-.highlight .gi { color: #000000; background-color: #ddffdd } /* Generic.Inserted */
-.highlight .gi .x { color: #000000; background-color: #aaffaa } /* Generic.Inserted.Specific */
-.highlight .go { color: #888888 } /* Generic.Output */
-.highlight .gp { color: #555555 } /* Generic.Prompt */
+.highlight .gr { color: var(--base02) } /* Generic.Error */
+.highlight .gh { color: var(--base08) } /* Generic.Heading */
+.highlight .gi { background-color: var(--base09); border: 1px solid var(--base04); } /* Generic.Inserted */
+.highlight .gi .x { background-color: var(--base09); border: 1px solid var(--base04); } /* Generic.Inserted.Specific */
+.highlight .go { color: var(--base13) } /* Generic.Output */
+.highlight .gp { color: var(--base0A) } /* Generic.Prompt */
 .highlight .gs { font-weight: bold } /* Generic.Strong */
-.highlight .gu { color: #aaaaaa } /* Generic.Subheading */
-.highlight .gt { color: #aa0000 } /* Generic.Traceback */
-.highlight .kc { font-weight: bold } /* Keyword.Constant */
-.highlight .kd { font-weight: bold } /* Keyword.Declaration */
-.highlight .kp { font-weight: bold } /* Keyword.Pseudo */
-.highlight .kr { font-weight: bold } /* Keyword.Reserved */
-.highlight .kt { color: #445588; font-weight: bold } /* Keyword.Type */
-.highlight .m { color: #009999 } /* Literal.Number */
-.highlight .s { color: #d14 } /* Literal.String */
-.highlight .na { color: #008080 } /* Name.Attribute */
-.highlight .nb { color: #0086B3 } /* Name.Builtin */
-.highlight .nc { color: #445588; font-weight: bold } /* Name.Class */
-.highlight .no { color: #008080 } /* Name.Constant */
-.highlight .ni { color: #800080 } /* Name.Entity */
-.highlight .ne { color: #990000; font-weight: bold } /* Name.Exception */
-.highlight .nf { color: #990000; font-weight: bold } /* Name.Function */
-.highlight .nn { color: #555555 } /* Name.Namespace */
-.highlight .nt { color: #000080 } /* Name.Tag */
-.highlight .nv { color: #008080 } /* Name.Variable */
-.highlight .ow { font-weight: bold } /* Operator.Word */
-.highlight .w { color: #bbbbbb } /* Text.Whitespace */
-.highlight .mf { color: #009999 } /* Literal.Number.Float */
-.highlight .mh { color: #009999 } /* Literal.Number.Hex */
-.highlight .mi { color: #009999 } /* Literal.Number.Integer */
-.highlight .mo { color: #009999 } /* Literal.Number.Oct */
-.highlight .sb { color: #d14 } /* Literal.String.Backtick */
-.highlight .sc { color: #d14 } /* Literal.String.Char */
-.highlight .sd { color: #d14 } /* Literal.String.Doc */
-.highlight .s2 { color: #d14 } /* Literal.String.Double */
-.highlight .se { color: #d14 } /* Literal.String.Escape */
-.highlight .sh { color: #d14 } /* Literal.String.Heredoc */
-.highlight .si { color: #d14 } /* Literal.String.Interpol */
-.highlight .sx { color: #d14 } /* Literal.String.Other */
-.highlight .sr { color: #009926 } /* Literal.String.Regex */
-.highlight .s1 { color: #d14 } /* Literal.String.Single */
-.highlight .ss { color: #990073 } /* Literal.String.Symbol */
-.highlight .bp { color: #999999 } /* Name.Builtin.Pseudo */
-.highlight .vc { color: #008080 } /* Name.Variable.Class */
-.highlight .vg { color: #008080 } /* Name.Variable.Global */
-.highlight .vi { color: #008080 } /* Name.Variable.Instance */
-.highlight .il { color: #009999 } /* Literal.Number.Integer.Long */
+.highlight .gu { color: var(--base08) } /* Generic.Subheading */
+.highlight .gt { color: var(--base0E) } /* Generic.Traceback */
+.highlight .kc { color: var(--base0B); font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: var(--base04); font-weight: bold } /* Keyword.Declaration */
+.highlight .kp { color: var(--base0C); font-weight: bold } /* Keyword.Pseudo */
+.highlight .kr { color: var(--base0C); font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: var(--base0B); font-weight: bold } /* Keyword.Type */
+.highlight .m { color: var(--base04); } /* Literal.Number */
+.highlight .s { color: var(--base02); } /* Literal.String */
+.highlight .na { color: var(--base04); } /* Name.Attribute */
+.highlight .nb { color: var(--base04); } /* Name.Builtin */
+.highlight .nc { color: var(--base03); font-weight: bold } /* Name.Class */
+.highlight .no { color: var(--base04); } /* Name.Constant */
+.highlight .ni { color: var(--base06); } /* Name.Entity */
+.highlight .ne { color: var(--base02); font-weight: bold } /* Name.Exception */
+.highlight .nf { color: var(--base0E); font-weight: bold } /* Name.Function */
+.highlight .nn { color: var(--base02); } /* Name.Namespace */
+.highlight .nt { color: var(--base03); } /* Name.Tag */
+.highlight .nv { color: var(--base02); } /* Name.Variable */
+.highlight .ow { color: var(--base0F); font-weight: bold } /* Operator.Word */
+.highlight .w { color: var(--base10) } /* Text.Whitespace */
+.highlight .mf { color: var(--base0E) } /* Literal.Number.Float */
+.highlight .mh { color: var(--base04) } /* Literal.Number.Hex */
+.highlight .mi { color: var(--base04) } /* Literal.Number.Integer */
+.highlight .mo { color: var(--base04) } /* Literal.Number.Oct */
+.highlight .sb { color: var(--base02) } /* Literal.String.Backtick */
+.highlight .sc { color: var(--base02) } /* Literal.String.Char */
+.highlight .sd { color: var(--base02); font-style: italic; } /* Literal.String.Doc */
+.highlight .s2 { color: var(--base02) } /* Literal.String.Double */
+.highlight .se { color: var(--base02) } /* Literal.String.Escape */
+.highlight .sh { color: var(--base02) } /* Literal.String.Heredoc */
+.highlight .si { color: var(--base02) } /* Literal.String.Interpol */
+.highlight .sx { color: var(--base02) } /* Literal.String.Other */
+.highlight .sr { color: var(--base0E) } /* Literal.String.Regex */
+.highlight .s1 { color: var(--base02) } /* Literal.String.Single */
+.highlight .ss { color: var(--base11) } /* Literal.String.Symbol */
+.highlight .bp { color: var(--base01) } /* Name.Builtin.Pseudo */
+.highlight .vc { color: var(--base04) } /* Name.Variable.Class */
+.highlight .vg { color: var(--base04) } /* Name.Variable.Global */
+.highlight .vi { color: var(--base04) } /* Name.Variable.Instance */
+.highlight .il { color: var(--base04) } /* Literal.Number.Integer.Long */


### PR DESCRIPTION
Just took highlighting syntax from Boosted and adapted to `highlighter-rouge`.